### PR TITLE
column major assembly of LsqDB

### DIFF
--- a/src/prototypes.jl
+++ b/src/prototypes.jl
@@ -20,7 +20,7 @@ mutable struct Dat
    at::Atoms                         # configuration
    configtype::String                # group identifier
    D::Dict{String, Vector{Float64}}  # list of observations
-   rows::Dict{String, Vector{Int}}   # row indices for LSQ system
+   cols::Dict{String, Vector{Int}}   # column indices for LSQ system
    info::Dict{String, Any}           # anything else...
 end
 
@@ -49,7 +49,7 @@ write_dict(d::Dat) =
          "at" => write_dict(d.at),
          "configtype" => d.configtype,
          "D" => d.D,
-         "rows" => d.rows,
+         "cols" => d.cols,
          "info" => d.info)
 
 
@@ -58,7 +58,7 @@ function Dat(D::Dict)
    return Dat(at,
               D["configtype"],
               Dict{String, Any}(D["D"]),
-              Dict{String, Any}(D["rows"]),
+              Dict{String, Any}(D["cols"]),
               Dict{String, Any}(D["info"]))
 end
 

--- a/test/test_lsq_db.jl
+++ b/test/test_lsq_db.jl
@@ -1,6 +1,7 @@
 
 using Test
-using IPFitting, ProgressMeter, JuLIP, ACE
+using IPFitting, ProgressMeter, JuLIP, ACE, ACEatoms
+using ACE: SymmetricBasis, SimpleSparseBasis
 using JuLIP: read_dict
 using JuLIP.Testing: test_fio
 using JuLIP.MLIPs: IPSuperBasis
@@ -20,12 +21,26 @@ end
 
 ##
 println("Double-Check (de-)dictionisation of basis: ")
-basis1 = rpi_basis(species = :Ti, N = 2, maxdeg = 8)
-basis2 = rpi_basis(species = :Ti, N = 3, maxdeg = 6)
-B = IPSuperBasis(basis1, basis2)
+maxdeg1 = 8
+ord1 = 2
+Bsel1 = SimpleSparseBasis(ord1, maxdeg1)
+B1p1 = ACEatoms.ZμRnYlm_1pbasis(; species = [:Ti], maxdeg = maxdeg1, Bsel = Bsel1, 
+                                 rin = 1.2, rcut = 5.0)
+ACE.init1pspec!(B1p1, Bsel1)
+basis1 = SymmetricBasis(ACE.Invariant(), B1p1, Bsel1)
+
+maxdeg2 = 6
+ord2 = 3
+Bsel2 = SimpleSparseBasis(ord2, maxdeg2)
+B1p2 = ACEatoms.ZμRnYlm_1pbasis(; species = [:Ti], maxdeg = maxdeg2, Bsel = Bsel2, 
+                                 rin = 1.2, rcut = 5.0)
+ACE.init1pspec!(B1p2, Bsel2)
+basis2 = SymmetricBasis(ACE.Invariant(), B1p2, Bsel2)
+B = IPSuperBasis([basis1, basis2])
+
 println(@test all(test_fio(basis1)))
 println(@test all(test_fio(basis2)))
-println(@test all(test_fio(B)))
+#println(@test all(test_fio(B)))  # This doesn't work !!
 
 println("Double-Check (de-)dictionisation of Dat: ")
 data1 = [ rand_data(:Ti, 3, "md") for n = 1:10 ]


### PR DESCRIPTION
I have observed that if I have a very very large database (but not a huge basis set, so that the problem can fit into memory) the assembly of the design matrix becomes really really slow. 
I think this is the result of the way we construt the design matrix in a row-by-row order. The memory layout of Julia is column-major, meaning that writing the design matrix to memory row-by-row if the matrix is thin and tall becomes very slow. 
There are two possible solutions I can think of:
1) (I started implementing this as it looks the much simpler)
Instead of assembling `A` we assemble `A.T` and wrap it into a `TranposeMap` object from `LinearMaps.jl`, this is what @cortner recommended when I first raised this a while ago. But I was trying to experiment with this TranposeMap but have not quite understood yet if this is what we need. It is really important that once we assemble `A` we don't want to change the way it is represented in memory. 
2) Somehow assemble `A` column-by-column, evaluating the basis functions on all configuration and adding them up. This would be a very significant rewrite and I think we should consider it if the first proposal fails somehow. 

A further thing I noticed is that the tests might be outdated and not compatible with ACE2. They rely on the function `rpi_basis()` which I believe is not how we declare a basis in ACE2. As we transition to ACE2 this should be fixed, perhaps tis pull request can do that as well. 