### PR TITLE
remove normalize=true from bayesian solvers.

### DIFF
--- a/src/lsq.jl
+++ b/src/lsq.jl
@@ -484,7 +484,7 @@ end
       brr_tol = solver["brr_tol"]
       @info("Using BRR: brr_tol=$(brr_tol)")
 
-      clf = BRR(tol=brr_tol, normalize=true, compute_score=true)
+      clf = BRR(tol=brr_tol, fit_intercept=false, compute_score=true)
       clf.fit(Ψ, Y)
 
       c = clf.coef_
@@ -502,7 +502,7 @@ end
       ard_tol = solver["ard_tol"]
       @info("Using ARD: ard_tol=$(ard_tol), ard_threshold_lambda=$(ard_threshold_lambda)")
 
-      clf = ARD(threshold_lambda = ard_threshold_lambda, tol=ard_tol, normalize=true, compute_score=true)
+      clf = ARD(threshold_lambda = ard_threshold_lambda, tol=ard_tol, fit_intercept=false, compute_score=true)
       clf.fit(Ψ, Y)
 
       c = clf.coef_


### PR DESCRIPTION
Alters the calls to `BayesianRidge` and `ARDRegression` to use `fit_intercept=false` (and therefore `normalize=false` implicitly). Corrects a small inconsistency (see below) that should improve test errors (although possibly only negligibly).

There is a downside, which is that `normalize=true` helps with the numerics, so the routines may be less stable now. However, after discussing with @casv2, we think it's best to correct the immediate issue and return to the normalization if needed. (It's also the case that `normalize=true` is deprecated [#35], so we'd need to change it eventually anyway.)

This is a breaking change, so may warrant some discussion (@cortner, @bernstei, @gelzinyte, others?).

### Background

Currently, the `BayesianRidge` and `ARDRegression` solvers from `sklearn` are called with `normalize=true`, which means the data are rescaled before the fit according to
```
X'_ij = (X_ij - Xoffset_j) / Xscale_j
Y_i' = Y_i - Yoffset
```
Let `c'` be the fit coefficients obtained using `X'` and `Y'`. To make predictions, `sklearn` uses
```
y = <x', c'> + Yoffset
  = <x, c> + intercept

with  c_j = c'_j / Xscale_j
      intercept = Yoffset - <Xoffset, c>
```
However, `IPFitting` makes predictions with
```
y = <x,c>
```
without the intercept.

### Why not just fit the intercept and use it?

I'm a little unsure about this part. From @casv2, I gather it's because we want to set the intercept ourselves using `E0` values. But I'm a little hazy on how it all fits together.